### PR TITLE
fix: iphone config relative root path

### DIFF
--- a/configs/Dynamic/Wild_SLAM_iPhone/wild_slam_iphone.yaml
+++ b/configs/Dynamic/Wild_SLAM_iPhone/wild_slam_iphone.yaml
@@ -3,7 +3,7 @@ inherit_from: ./configs/wildgs_slam.yaml
 dataset: 'wild_slam_iphone'
 
 data:
-  root_folder: /home/jianhaozheng/Gaussian_in_the_Wild/data/wild-slam/iphone
+  root_folder: ./datasets/Wild_SLAM_iPhone
   output: ./output/Wild_SLAM_iPhone
   
 cam:


### PR DESCRIPTION
The iPhone config was pointing to a local path. I changed it to use a relative path in the same way as the other configs already do.